### PR TITLE
Add request metadata to context (try #2)

### DIFF
--- a/context.go
+++ b/context.go
@@ -7,6 +7,7 @@ import (
 )
 
 type requestIDKey struct{}
+type methodNameKey struct{}
 
 // RequestID takes request id from context.
 func RequestID(c context.Context) *fastjson.RawMessage {
@@ -16,4 +17,14 @@ func RequestID(c context.Context) *fastjson.RawMessage {
 // WithRequestID adds request id to context.
 func WithRequestID(c context.Context, id *fastjson.RawMessage) context.Context {
 	return context.WithValue(c, requestIDKey{}, id)
+}
+
+// MethodName takes method name from context.
+func MethodName(c context.Context) string {
+	return c.Value(methodNameKey{}).(string)
+}
+
+// WithMethodName adds method name to context.
+func WithMethodName(c context.Context, name string) context.Context {
+	return context.WithValue(c, methodNameKey{}, name)
 }

--- a/context.go
+++ b/context.go
@@ -7,6 +7,7 @@ import (
 )
 
 type requestIDKey struct{}
+type metadataIDKey struct{}
 type methodNameKey struct{}
 
 // RequestID takes request id from context.
@@ -17,6 +18,16 @@ func RequestID(c context.Context) *fastjson.RawMessage {
 // WithRequestID adds request id to context.
 func WithRequestID(c context.Context, id *fastjson.RawMessage) context.Context {
 	return context.WithValue(c, requestIDKey{}, id)
+}
+
+// RequestID takes request id from context.
+func GetMetadata(c context.Context) Metadata {
+	return c.Value(metadataIDKey{}).(Metadata)
+}
+
+// WithRequestID adds request id to context.
+func WithMetadata(c context.Context, md Metadata) context.Context {
+	return context.WithValue(c, metadataIDKey{}, md)
 }
 
 // MethodName takes method name from context.

--- a/context.go
+++ b/context.go
@@ -20,12 +20,12 @@ func WithRequestID(c context.Context, id *fastjson.RawMessage) context.Context {
 	return context.WithValue(c, requestIDKey{}, id)
 }
 
-// RequestID takes request id from context.
+// GetMetadata takes jsonrpc metadata from context.
 func GetMetadata(c context.Context) Metadata {
 	return c.Value(metadataIDKey{}).(Metadata)
 }
 
-// WithRequestID adds request id to context.
+// WithMetadata adds jsonrpc metadata to context.
 func WithMetadata(c context.Context, md Metadata) context.Context {
 	return context.WithValue(c, metadataIDKey{}, md)
 }

--- a/context_test.go
+++ b/context_test.go
@@ -20,6 +20,18 @@ func TestRequestID(t *testing.T) {
 	require.Equal(t, &id, pick)
 }
 
+func TestMetadata(t *testing.T) {
+
+	c := context.Background()
+	md := Metadata{Params: Metadata{}}
+	c = WithMetadata(c, md)
+	var pick Metadata
+	require.NotPanics(t, func() {
+		pick = GetMetadata(c)
+	})
+	require.Equal(t, md, pick)
+}
+
 func TestMethodName(t *testing.T) {
 
 	c := context.Background()

--- a/context_test.go
+++ b/context_test.go
@@ -19,3 +19,14 @@ func TestRequestID(t *testing.T) {
 	})
 	require.Equal(t, &id, pick)
 }
+
+func TestMethodName(t *testing.T) {
+
+	c := context.Background()
+	c = WithMethodName(c, t.Name())
+	var pick string
+	require.NotPanics(t, func() {
+		pick = MethodName(c)
+	})
+	require.Equal(t, t.Name(), pick)
+}

--- a/handler.go
+++ b/handler.go
@@ -50,9 +50,10 @@ func (mr *MethodRepository) InvokeMethod(c context.Context, r *Request) *Respons
 	if res.Error != nil {
 		return res
 	}
+
 	wrappedContext := WithRequestID(c, r.ID)
 	wrappedContext = WithMethodName(wrappedContext, r.Method)
-	res.Result, res.Error = h.ServeJSONRPC(WithRequestID(c, r.ID), r.Params)
+	res.Result, res.Error = h.ServeJSONRPC(wrappedContext, r.Params)
 	if res.Error != nil {
 		res.Result = nil
 	}

--- a/handler.go
+++ b/handler.go
@@ -13,6 +13,17 @@ type Handler interface {
 	ServeJSONRPC(c context.Context, params *fastjson.RawMessage) (result interface{}, err *Error)
 }
 
+// HandlerFunc type is an adapter to allow the use of
+// ordinary functions as JSONRPC handlers. If f is a function
+// with the appropriate signature, HandlerFunc(f) is a
+// jsonrpc.Handler that calls f.
+type HandlerFunc func(c context.Context, params *fastjson.RawMessage) (result interface{}, err *Error)
+
+// ServeJSONRPC calls f(w, r).
+func (f HandlerFunc) ServeJSONRPC(c context.Context, params *fastjson.RawMessage) (result interface{}, err *Error) {
+	return f(c, params)
+}
+
 // ServeHTTP provides basic JSON-RPC handling.
 func (mr *MethodRepository) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 

--- a/handler.go
+++ b/handler.go
@@ -50,6 +50,8 @@ func (mr *MethodRepository) InvokeMethod(c context.Context, r *Request) *Respons
 	if res.Error != nil {
 		return res
 	}
+	wrappedContext := WithRequestID(c, r.ID)
+	wrappedContext = WithMethodName(wrappedContext, r.Method)
 	res.Result, res.Error = h.ServeJSONRPC(WithRequestID(c, r.ID), r.Params)
 	if res.Error != nil {
 		res.Result = nil

--- a/handler.go
+++ b/handler.go
@@ -55,16 +55,17 @@ func (mr *MethodRepository) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // InvokeMethod invokes JSON-RPC method.
 func (mr *MethodRepository) InvokeMethod(c context.Context, r *Request) *Response {
-	var h Handler
+	var md Metadata
 	res := NewResponse(r)
-	h, res.Error = mr.TakeMethod(r)
+	md, res.Error = mr.TakeMethodMetadata(r)
 	if res.Error != nil {
 		return res
 	}
 
 	wrappedContext := WithRequestID(c, r.ID)
 	wrappedContext = WithMethodName(wrappedContext, r.Method)
-	res.Result, res.Error = h.ServeJSONRPC(wrappedContext, r.Params)
+	wrappedContext = WithMetadata(wrappedContext, md)
+	res.Result, res.Error = md.Handler.ServeJSONRPC(wrappedContext, r.Params)
 	if res.Error != nil {
 		res.Result = nil
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -12,14 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type handler struct {
-	F func(c context.Context, params *fastjson.RawMessage) (interface{}, *Error)
-}
-
-func (h *handler) ServeJSONRPC(c context.Context, params *fastjson.RawMessage) (interface{}, *Error) {
-	return h.F(c, params)
-}
-
 func TestHandler(t *testing.T) {
 
 	mr := NewMethodRepository()
@@ -46,15 +38,13 @@ func TestHandler(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, res.Error)
 
-	h1 := &handler{}
-	h1.F = func(c context.Context, params *fastjson.RawMessage) (interface{}, *Error) {
+	h1 := HandlerFunc(func(c context.Context, params *fastjson.RawMessage) (interface{}, *Error) {
 		return "hello", nil
-	}
+	})
 	require.NoError(t, mr.RegisterMethod("hello", h1, nil, nil))
-	h2 := &handler{}
-	h2.F = func(c context.Context, params *fastjson.RawMessage) (interface{}, *Error) {
+	h2 := HandlerFunc(func(c context.Context, params *fastjson.RawMessage) (interface{}, *Error) {
 		return nil, ErrInternal()
-	}
+	})
 	require.NoError(t, mr.RegisterMethod("bye", h2, nil, nil))
 
 	rec = httptest.NewRecorder()

--- a/method.go
+++ b/method.go
@@ -27,19 +27,29 @@ func NewMethodRepository() *MethodRepository {
 	}
 }
 
-// TakeMethod takes jsonrpc.Func in MethodRepository.
-func (mr *MethodRepository) TakeMethod(r *Request) (Handler, *Error) {
+// TakeMethodMetadata takes metadata in MethodRepository for request.
+func (mr *MethodRepository) TakeMethodMetadata(r *Request) (Metadata, *Error) {
+
 	if r.Method == "" || r.Version != Version {
-		return nil, ErrInvalidParams()
+		return Metadata{}, ErrInvalidParams()
 	}
 
 	mr.m.RLock()
 	md, ok := mr.r[r.Method]
 	mr.m.RUnlock()
 	if !ok {
-		return nil, ErrMethodNotFound()
+		return Metadata{}, ErrMethodNotFound()
 	}
 
+	return md, nil
+}
+
+// TakeMethod takes jsonrpc.Func in MethodRepository.
+func (mr *MethodRepository) TakeMethod(r *Request) (Handler, *Error) {
+	md, err := mr.TakeMethodMetadata(r)
+	if err != nil {
+		return nil, err
+	}
 	return md.Handler, nil
 }
 

--- a/method_test.go
+++ b/method_test.go
@@ -62,9 +62,9 @@ func TestMethods(t *testing.T) {
 }
 
 func SampleHandler() Handler {
-	h := handler{}
-	h.F = func(c context.Context, params *fastjson.RawMessage) (result interface{}, err *Error) {
+
+	h := HandlerFunc(func(c context.Context, params *fastjson.RawMessage) (result interface{}, err *Error) {
 		return nil, nil
-	}
+	})
 	return &h
 }


### PR DESCRIPTION
## WHAT
See header

## WHY
Metadata in context allows params unmarshalling as a general step for processing jsonrpc request

First my try to mege this PR was failed because of some git-and-rebase-related problems. This is second try